### PR TITLE
Reorganizing, refactoring, renaming transform method

### DIFF
--- a/lda/lda.py
+++ b/lda/lda.py
@@ -198,7 +198,7 @@ class LDA:
         for iteration in range(max_iter + 1): # +1 is for initialization
             PZS_new = self.components_[:, doc].T
             PZS_new *= (PZS.sum(axis=0) - PZS + self.alpha)
-            PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis]
+            PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis] # vector to single column matrix
             delta_naive = np.abs(PZS_new - PZS).sum()
             logger.debug('transform iter {}, delta {}'.format(iteration, delta_naive))
             PZS = PZS_new

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -200,7 +200,7 @@ class LDA:
             PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis]
             delta_naive = np.abs(PZS_new - PZS).sum()
             logger.debug('transform iter {}, delta {}'.format(iteration, delta_naive))
-            PZS = PZS_new.copy()
+            PZS = PZS_new
             if delta_naive < tol:
                 break
         theta_doc = PZS.sum(axis=0) / PZS.sum()

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -177,7 +177,7 @@ class LDA:
             doc_topic[d] = self._transform_single(WS[DS == d], max_iter, tol)
         return doc_topic
 
-    def _transform_single(self, ws_doc, max_iter, tol):
+    def _transform_single(self, doc, max_iter, tol):
         """Transform a single document according to the previously fit model
 
         Parameters
@@ -195,20 +195,20 @@ class LDA:
             Point estimate of the topic distributions for document
         """
         # initialization step
-        PZS = (self.components_[:, ws_doc].T * self.alpha).astype(float)
+        PZS = (self.components_[:, doc].T * self.alpha).astype(float)
         # NOTE: numpy /= is integer division
         PZS /= PZS.sum(axis=1)[:, np.newaxis]
-        assert PZS.shape == (len(ws_doc), self.n_topics)
+        assert PZS.shape == (len(doc), self.n_topics)
         PZS_new = np.empty_like(PZS)
-        for s in range(max_iter):
+        for iteration in range(max_iter):
             PZS_sum = PZS.sum(axis=0)
-            for i, w in enumerate(ws_doc):
+            for i, word in enumerate(doc):
                 PZS_sum -= PZS[i]
-                PZS_new[i] = self.components_[:, w] * (PZS_sum + self.alpha)
+                PZS_new[i] = self.components_[:, word] * (PZS_sum + self.alpha)
                 PZS_sum += PZS[i]
             PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis]
             delta_naive = np.abs(PZS_new - PZS).sum()
-            logger.debug('transform iter {}, delta {}'.format(s, delta_naive))
+            logger.debug('transform iter {}, delta {}'.format(iteration, delta_naive))
             PZS = PZS_new.copy()
             if delta_naive < tol:
                 break

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -194,15 +194,10 @@ class LDA:
         doc_topic : 1D numpy array of length n_topics
             Point estimate of the topic distributions for document
         """
-        # initialization step
-        PZS = (self.components_[:, doc].T * self.alpha).astype(float)
-        # NOTE: numpy /= is integer division
-        PZS /= PZS.sum(axis=1)[:, np.newaxis]
-        assert PZS.shape == (len(doc), self.n_topics)
+        PZS = np.zeros((len(doc), self.n_topics))
         PZS_new = np.empty_like(PZS)
-        for iteration in range(max_iter):
-            PZS_sum = PZS.sum(axis=0)
-            PZS_new = self.components_[:, doc].T * (PZS_sum - PZS + self.alpha)
+        for iteration in range(max_iter + 1): # +1 is for initialization
+            PZS_new = self.components_[:, doc].T * (PZS.sum(axis=0) - PZS + self.alpha)
             PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis]
             delta_naive = np.abs(PZS_new - PZS).sum()
             logger.debug('transform iter {}, delta {}'.format(iteration, delta_naive))

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -212,8 +212,7 @@ class LDA:
             PZS = PZS_new.copy()
             if delta_naive < tol:
                 break
-        theta_doc = PZS.sum(axis=0)
-        theta_doc /= sum(theta_doc)
+        theta_doc = PZS.sum(axis=0) / PZS.sum()
         assert len(theta_doc) == self.n_topics
         assert theta_doc.shape == (self.n_topics,)
         return theta_doc

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -196,7 +196,8 @@ class LDA:
         """
         PZS = np.zeros((len(doc), self.n_topics))
         for iteration in range(max_iter + 1): # +1 is for initialization
-            PZS_new = self.components_[:, doc].T * (PZS.sum(axis=0) - PZS + self.alpha)
+            PZS_new = self.components_[:, doc].T
+            PZS_new *= (PZS.sum(axis=0) - PZS + self.alpha)
             PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis]
             delta_naive = np.abs(PZS_new - PZS).sum()
             logger.debug('transform iter {}, delta {}'.format(iteration, delta_naive))

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -195,7 +195,6 @@ class LDA:
             Point estimate of the topic distributions for document
         """
         PZS = np.zeros((len(doc), self.n_topics))
-        PZS_new = np.empty_like(PZS)
         for iteration in range(max_iter + 1): # +1 is for initialization
             PZS_new = self.components_[:, doc].T * (PZS.sum(axis=0) - PZS + self.alpha)
             PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis]

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -202,8 +202,7 @@ class LDA:
         PZS_new = np.empty_like(PZS)
         for iteration in range(max_iter):
             PZS_sum = PZS.sum(axis=0)
-            for i, word in enumerate(doc):
-                PZS_new[i] = self.components_[:, word] * (PZS_sum - PZS[i] + self.alpha)
+            PZS_new = self.components_[:, doc].T * (PZS_sum - PZS + self.alpha)
             PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis]
             delta_naive = np.abs(PZS_new - PZS).sum()
             logger.debug('transform iter {}, delta {}'.format(iteration, delta_naive))

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -203,9 +203,7 @@ class LDA:
         for iteration in range(max_iter):
             PZS_sum = PZS.sum(axis=0)
             for i, word in enumerate(doc):
-                PZS_sum -= PZS[i]
-                PZS_new[i] = self.components_[:, word] * (PZS_sum + self.alpha)
-                PZS_sum += PZS[i]
+                PZS_new[i] = self.components_[:, word] * (PZS_sum - PZS[i] + self.alpha)
             PZS_new /= PZS_new.sum(axis=1)[:, np.newaxis]
             delta_naive = np.abs(PZS_new - PZS).sum()
             logger.debug('transform iter {}, delta {}'.format(iteration, delta_naive))


### PR DESCRIPTION
I was trying to understand the computations being done by `transform()`, and I reworked it in the process. I create a new method (`_transform_single`) that does the transformation computations on a single document (the other loop of transform). 

I converted the inner loop into a vectorized calculation on PZS_new.

I removed redundant code by skipping the initialization step.

I removed some local variables and used object members instead. 

Did a few other cleanups.